### PR TITLE
feat(core): add schedule opcodes for time-based workflow control

### DIFF
--- a/examples/scheduling/daily_schedule.yaml
+++ b/examples/scheduling/daily_schedule.yaml
@@ -1,0 +1,78 @@
+# Daily Schedule Example
+# Demonstrates scheduling a task to run every day at a specific time.
+# This example runs once (max_iterations=1) at 09:00 in Sao Paulo timezone.
+#
+# Run with: lexflow examples/scheduling/daily_schedule.yaml
+#
+# For production use, remove max_iterations to run indefinitely,
+# or combine with control_spawn to run alongside other tasks.
+
+workflows:
+  - name: main
+    interface:
+      inputs: []
+      outputs: []
+    variables:
+      tick: null
+
+    nodes:
+      start:
+        opcode: workflow_start
+        next: print_intro
+        inputs: {}
+
+      print_intro:
+        opcode: io_print
+        next: process_ticks
+        inputs:
+          STRING: { literal: "Waiting for 09:00 AM (America/Sao_Paulo)...\n" }
+
+      create_daily:
+        opcode: schedule_daily
+        isReporter: true
+        inputs:
+          hour: { literal: 9 }
+          minute: { literal: 0 }
+          timezone: { literal: "America/Sao_Paulo" }
+          max_iterations: { literal: 1 }
+
+      process_ticks:
+        opcode: control_async_foreach
+        next: done
+        inputs:
+          VAR: { literal: "tick" }
+          ITERABLE: { node: create_daily }
+          BODY: { branch: execute_daily_task }
+
+      execute_daily_task:
+        opcode: io_print
+        next: null
+        inputs:
+          STRING: { node: format_msg }
+
+      format_msg:
+        opcode: operator_add
+        isReporter: true
+        inputs:
+          A: { literal: "Daily task executed at " }
+          B: { node: format_msg_suffix }
+
+      format_msg_suffix:
+        opcode: operator_add
+        isReporter: true
+        inputs:
+          A: { node: get_time }
+          B: { literal: "\n" }
+
+      get_time:
+        opcode: dict_get
+        isReporter: true
+        inputs:
+          d: { variable: tick }
+          key: { literal: "actual_time" }
+
+      done:
+        opcode: io_print
+        next: null
+        inputs:
+          STRING: { literal: "Daily schedule completed.\n" }

--- a/examples/scheduling/delayed_action.yaml
+++ b/examples/scheduling/delayed_action.yaml
@@ -1,0 +1,70 @@
+# Delayed Action Example
+# Waits for a specified delay before executing an action.
+#
+# Run with: lexflow examples/scheduling/delayed_action.yaml
+
+workflows:
+  - name: main
+    interface:
+      inputs: []
+      outputs: []
+    variables:
+      timing: null
+
+    nodes:
+      start:
+        opcode: workflow_start
+        next: print_waiting
+        inputs: {}
+
+      print_waiting:
+        opcode: io_print
+        next: store_timing
+        inputs:
+          STRING: { literal: "Waiting 3 seconds...\n" }
+
+      delay:
+        opcode: schedule_after
+        isReporter: true
+        inputs:
+          seconds: { literal: 3 }
+
+      store_timing:
+        opcode: data_set_variable_to
+        next: print_done
+        inputs:
+          VARIABLE: { literal: "timing" }
+          VALUE: { node: delay }
+
+      print_done:
+        opcode: io_print
+        next: print_elapsed
+        inputs:
+          STRING: { literal: "Action executed!\n" }
+
+      print_elapsed:
+        opcode: io_print
+        next: null
+        inputs:
+          STRING: { node: format_elapsed }
+
+      format_elapsed:
+        opcode: operator_add
+        isReporter: true
+        inputs:
+          A: { literal: "Elapsed: " }
+          B: { node: format_elapsed_suffix }
+
+      format_elapsed_suffix:
+        opcode: operator_add
+        isReporter: true
+        inputs:
+          A: { node: get_elapsed }
+          B: { literal: " seconds\n" }
+
+      get_elapsed:
+        opcode: dict_get
+        isReporter: true
+        inputs:
+          d: { variable: timing }
+          key: { literal: "elapsed_seconds" }

--- a/examples/scheduling/interval_timer.yaml
+++ b/examples/scheduling/interval_timer.yaml
@@ -1,0 +1,93 @@
+# Interval Timer Example
+# Prints a message every 2 seconds, stopping after 5 iterations.
+#
+# Run with: lexflow examples/scheduling/interval_timer.yaml
+
+workflows:
+  - name: main
+    interface:
+      inputs: []
+      outputs: []
+    variables:
+      tick: null
+
+    nodes:
+      start:
+        opcode: workflow_start
+        next: print_intro
+        inputs: {}
+
+      print_intro:
+        opcode: io_print
+        next: process_ticks
+        inputs:
+          STRING: { literal: "Starting interval timer (every 2s, 5 iterations)...\n\n" }
+
+      create_interval:
+        opcode: schedule_interval
+        isReporter: true
+        inputs:
+          seconds: { literal: 2 }
+          max_iterations: { literal: 5 }
+
+      process_ticks:
+        opcode: control_async_foreach
+        next: done
+        inputs:
+          VAR: { literal: "tick" }
+          ITERABLE: { node: create_interval }
+          BODY: { branch: print_tick }
+
+      print_tick:
+        opcode: io_print
+        next: null
+        inputs:
+          STRING: { node: format_tick }
+
+      format_tick:
+        opcode: operator_add
+        isReporter: true
+        inputs:
+          A: { literal: "Tick #" }
+          B: { node: format_tick_suffix }
+
+      format_tick_suffix:
+        opcode: operator_add
+        isReporter: true
+        inputs:
+          A: { node: get_iteration }
+          B: { node: format_time_part }
+
+      get_iteration:
+        opcode: dict_get
+        isReporter: true
+        inputs:
+          d: { variable: tick }
+          key: { literal: "iteration" }
+
+      format_time_part:
+        opcode: operator_add
+        isReporter: true
+        inputs:
+          A: { literal: " at " }
+          B: { node: format_time_suffix }
+
+      format_time_suffix:
+        opcode: operator_add
+        isReporter: true
+        inputs:
+          A: { node: get_actual_time }
+          B: { literal: "\n" }
+
+      get_actual_time:
+        opcode: dict_get
+        isReporter: true
+        inputs:
+          d: { variable: tick }
+          key: { literal: "actual_time" }
+
+      done:
+        opcode: io_print
+        next: null
+        inputs:
+          STRING: { literal: "\nTimer complete!\n" }

--- a/lexflow-core/src/lexflow/opcodes/__init__.py
+++ b/lexflow-core/src/lexflow/opcodes/__init__.py
@@ -16,6 +16,7 @@ from .opcodes_rag import register_rag_opcodes
 from . import opcodes_chat  # noqa: F401
 from . import opcodes_cli  # noqa: F401
 from . import opcodes_github  # noqa: F401
+from . import opcodes_schedule  # noqa: F401
 from . import opcodes_tasks  # noqa: F401
 
 # Register optional opcode modules (require external dependencies)

--- a/lexflow-core/src/lexflow/opcodes/__init__.py
+++ b/lexflow-core/src/lexflow/opcodes/__init__.py
@@ -11,6 +11,7 @@ from .opcodes_pubsub import register_pubsub_opcodes
 from .opcodes_pydantic_ai import register_pydantic_ai_opcodes
 from .opcodes_pygame import register_pygame_opcodes
 from .opcodes_rag import register_rag_opcodes
+from .opcodes_schedule import register_schedule_opcodes
 
 # Import opcodes that register via @opcode() decorator (no external dependencies)
 from . import opcodes_chat  # noqa: F401
@@ -26,6 +27,7 @@ register_pubsub_opcodes()
 register_pydantic_ai_opcodes()
 register_pygame_opcodes()
 register_rag_opcodes()
+register_schedule_opcodes()
 
 __all__ = [
     "CategoryInfo",

--- a/lexflow-core/src/lexflow/opcodes/opcodes_schedule.py
+++ b/lexflow-core/src/lexflow/opcodes/opcodes_schedule.py
@@ -1,0 +1,210 @@
+"""Schedule opcodes for LexFlow time-based workflow control.
+
+Provides one-shot delays, recurring intervals, daily timers,
+and cron-based scheduling as async generators for use with
+control_async_foreach.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from typing import AsyncGenerator, Optional
+from zoneinfo import ZoneInfo
+
+from .opcodes import opcode, register_category
+
+try:
+    from croniter import croniter
+
+    CRONITER_AVAILABLE = True
+except ImportError:
+    CRONITER_AVAILABLE = False
+
+
+register_category(
+    id="schedule",
+    label="Schedule Operations",
+    prefix="schedule_",
+    color="#F59E0B",
+    icon="⏰",
+    order=275,
+)
+
+
+def _now(tz: ZoneInfo) -> datetime:
+    return datetime.now(tz)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+@opcode(category="schedule")
+async def schedule_after(seconds: float, timezone: str = "UTC") -> dict:
+    """Wait for a delay then return timing info.
+
+    Args:
+        seconds: Number of seconds to wait
+        timezone: IANA timezone for timestamps (e.g. "America/Sao_Paulo")
+
+    Returns:
+        Dict with started_at, completed_at, elapsed_seconds
+    """
+    tz = ZoneInfo(timezone)
+    started_at = _now(tz)
+    await asyncio.sleep(seconds)
+    completed_at = _now(tz)
+    return {
+        "started_at": _iso(started_at),
+        "completed_at": _iso(completed_at),
+        "elapsed_seconds": (completed_at - started_at).total_seconds(),
+    }
+
+
+@opcode(category="schedule")
+async def schedule_interval(
+    seconds: float,
+    max_iterations: Optional[int] = None,
+    timezone: str = "UTC",
+) -> AsyncGenerator[dict, None]:
+    """Recurring fixed-rate timer as an async generator.
+
+    Uses fixed-rate scheduling measured from start time to prevent
+    drift accumulation. Use with control_async_foreach.
+
+    Args:
+        seconds: Interval between ticks in seconds
+        max_iterations: Stop after N iterations (None for infinite)
+        timezone: IANA timezone for timestamps
+
+    Yields:
+        Dict with iteration, scheduled_time, actual_time, drift_seconds,
+        next_scheduled_time
+    """
+    tz = ZoneInfo(timezone)
+
+    async def gen():
+        start = _now(tz)
+        iteration = 0
+        while max_iterations is None or iteration < max_iterations:
+            scheduled = start + timedelta(seconds=seconds * iteration)
+            if iteration > 0:
+                delay = (scheduled - _now(tz)).total_seconds()
+                if delay > 0:
+                    await asyncio.sleep(delay)
+            actual = _now(tz)
+            drift = (actual - scheduled).total_seconds()
+            next_scheduled = start + timedelta(seconds=seconds * (iteration + 1))
+            yield {
+                "iteration": iteration,
+                "scheduled_time": _iso(scheduled),
+                "actual_time": _iso(actual),
+                "drift_seconds": drift,
+                "next_scheduled_time": _iso(next_scheduled),
+            }
+            iteration += 1
+
+    return gen()
+
+
+@opcode(category="schedule")
+async def schedule_daily(
+    hour: int,
+    minute: int = 0,
+    second: int = 0,
+    timezone: str = "UTC",
+    max_iterations: Optional[int] = None,
+) -> AsyncGenerator[dict, None]:
+    """Daily timer that fires at a specific time each day.
+
+    If today's target time has already passed, the first fire is
+    scheduled for tomorrow. Use with control_async_foreach.
+
+    Args:
+        hour: Hour of day (0-23)
+        minute: Minute (0-59)
+        second: Second (0-59)
+        timezone: IANA timezone for scheduling
+        max_iterations: Stop after N iterations (None for infinite)
+
+    Yields:
+        Dict with iteration, scheduled_time, actual_time, drift_seconds,
+        next_scheduled_time
+    """
+    tz = ZoneInfo(timezone)
+
+    async def gen():
+        now = _now(tz)
+        target = now.replace(hour=hour, minute=minute, second=second, microsecond=0)
+        if target <= now:
+            target += timedelta(days=1)
+
+        iteration = 0
+        while max_iterations is None or iteration < max_iterations:
+            delay = (target - _now(tz)).total_seconds()
+            if delay > 0:
+                await asyncio.sleep(delay)
+            actual = _now(tz)
+            drift = (actual - target).total_seconds()
+            next_target = target + timedelta(days=1)
+            yield {
+                "iteration": iteration,
+                "scheduled_time": _iso(target),
+                "actual_time": _iso(actual),
+                "drift_seconds": drift,
+                "next_scheduled_time": _iso(next_target),
+            }
+            target = next_target
+            iteration += 1
+
+    return gen()
+
+
+if CRONITER_AVAILABLE:
+
+    @opcode(category="schedule")
+    async def schedule_cron(
+        expression: str,
+        max_iterations: Optional[int] = None,
+        timezone: str = "UTC",
+    ) -> AsyncGenerator[dict, None]:
+        """Cron-based recurring timer as an async generator.
+
+        Requires the croniter package. Use with control_async_foreach.
+
+        Args:
+            expression: Cron expression (e.g. "*/5 * * * *" for every 5 min)
+            max_iterations: Stop after N iterations (None for infinite)
+            timezone: IANA timezone for scheduling
+
+        Yields:
+            Dict with iteration, scheduled_time, actual_time, drift_seconds,
+            next_scheduled_time
+        """
+        tz = ZoneInfo(timezone)
+
+        async def gen():
+            now = _now(tz)
+            cron = croniter(expression, now)
+            iteration = 0
+            while max_iterations is None or iteration < max_iterations:
+                target = cron.get_next(datetime)
+                delay = (target - _now(tz)).total_seconds()
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                actual = _now(tz)
+                drift = (actual - target).total_seconds()
+                # Peek at next scheduled time with a separate iterator
+                peek = croniter(expression, target)
+                next_target = peek.get_next(datetime)
+                yield {
+                    "iteration": iteration,
+                    "scheduled_time": _iso(target),
+                    "actual_time": _iso(actual),
+                    "drift_seconds": drift,
+                    "next_scheduled_time": _iso(next_target),
+                }
+                iteration += 1
+
+        return gen()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,10 @@ http = ["aiohttp", "beautifulsoup4"]
 gcs = ["gcloud-aio-storage"]
 pubsub = ["gcloud-aio-pubsub"]
 rag = ["pypdf", "google-cloud-aiplatform", "qdrant-client", "bm25s"]
+schedule = ["croniter"]
 web = ["fastapi>=0.100.0", "uvicorn[standard]>=0.23.0"]
 dev = ["pytest", "pytest-asyncio"]
-all = ["lexflow[ai,pygame,file,http,web,rag,gcs,pubsub]"]
+all = ["lexflow[ai,pygame,file,http,web,rag,gcs,pubsub,schedule]"]
 
 [project.scripts]
 lexflow = "lexflow_cli.main:cli_main"

--- a/tests/unit/test_schedule_opcodes.py
+++ b/tests/unit/test_schedule_opcodes.py
@@ -1,92 +1,206 @@
 """Tests for schedule opcodes."""
 
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
 import pytest
 from lexflow import default_registry
 
 pytestmark = pytest.mark.asyncio
 
 
-async def test_schedule_after_returns_timing_info():
-    result = await default_registry.call("schedule_after", [0.05])
-    assert "started_at" in result
-    assert "completed_at" in result
-    assert "elapsed_seconds" in result
-    assert result["elapsed_seconds"] >= 0.05
+class TestScheduleAfter:
+    async def test_returns_timing_info(self):
+        result = await default_registry.call("schedule_after", [0.05])
+        assert "started_at" in result
+        assert "completed_at" in result
+        assert "elapsed_seconds" in result
+        assert result["elapsed_seconds"] >= 0.05
+
+    async def test_with_timezone(self):
+        result = await default_registry.call(
+            "schedule_after", [0.05, "America/Sao_Paulo"]
+        )
+        assert "started_at" in result
+        assert "-03:00" in result["started_at"] or "-02:00" in result["started_at"]
+
+    async def test_negative_seconds_raises(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            await default_registry.call("schedule_after", [-1])
+
+    async def test_zero_seconds_raises(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            await default_registry.call("schedule_after", [0])
+
+    async def test_exceeds_max_seconds_raises(self):
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            await default_registry.call("schedule_after", [86400 * 366])
+
+    async def test_invalid_timezone_raises(self):
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            await default_registry.call("schedule_after", [0.05, "Not/A_Timezone"])
 
 
-async def test_schedule_after_with_timezone():
-    result = await default_registry.call("schedule_after", [0.05, "America/Sao_Paulo"])
-    assert "started_at" in result
-    assert "-03:00" in result["started_at"] or "-02:00" in result["started_at"]
+class TestScheduleInterval:
+    async def test_yields_correct_count(self):
+        gen = await default_registry.call("schedule_interval", [0.02, 3])
+        ticks = []
+        async for tick in gen:
+            ticks.append(tick)
+        assert len(ticks) == 3
+
+    async def test_tick_structure(self):
+        gen = await default_registry.call("schedule_interval", [0.02, 1])
+        async for tick in gen:
+            assert "iteration" in tick
+            assert "scheduled_time" in tick
+            assert "actual_time" in tick
+            assert "drift_seconds" in tick
+            assert "next_scheduled_time" in tick
+            assert tick["iteration"] == 0
+
+    async def test_iterations_increment(self):
+        gen = await default_registry.call("schedule_interval", [0.02, 3])
+        iterations = []
+        async for tick in gen:
+            iterations.append(tick["iteration"])
+        assert iterations == [0, 1, 2]
+
+    async def test_with_timezone(self):
+        gen = await default_registry.call(
+            "schedule_interval", [0.02, 1, "America/Sao_Paulo"]
+        )
+        async for tick in gen:
+            assert (
+                "-03:00" in tick["scheduled_time"] or "-02:00" in tick["scheduled_time"]
+            )
+
+    async def test_negative_seconds_raises(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            await default_registry.call("schedule_interval", [-1])
+
+    async def test_invalid_timezone_raises(self):
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            await default_registry.call("schedule_interval", [1, None, "Bad/Zone"])
 
 
-async def test_schedule_interval_yields_correct_count():
-    gen = await default_registry.call("schedule_interval", [0.02, 3])
-    ticks = []
-    async for tick in gen:
-        ticks.append(tick)
-    assert len(ticks) == 3
+class TestScheduleDaily:
+    async def test_tick_structure(self):
+        gen = await default_registry.call("schedule_daily", [0, 0, 0, "UTC", 1])
+        assert hasattr(gen, "__aiter__")
+        assert hasattr(gen, "__anext__")
+
+    async def test_fires_with_correct_fields(self):
+        """Test daily generator yields correct structure using datetime mock."""
+        from lexflow.opcodes import opcodes_schedule
+
+        base = datetime(2025, 6, 15, 9, 59, 59, 0)
+        after_sleep = datetime(2025, 6, 15, 10, 0, 0, 5000)
+
+        call_count = 0
+
+        def mock_now(tz):
+            nonlocal call_count
+            call_count += 1
+            # Calls 1-2: before target (initial now + delay check)
+            if call_count <= 2:
+                return base.replace(tzinfo=tz)
+            # Call 3+: after sleep
+            return after_sleep.replace(tzinfo=tz)
+
+        with (
+            patch.object(opcodes_schedule, "_now", side_effect=mock_now),
+            patch("asyncio.sleep") as mock_sleep,
+        ):
+            gen = await default_registry.call("schedule_daily", [10, 0, 0, "UTC", 1])
+            ticks = []
+            async for tick in gen:
+                ticks.append(tick)
+
+            assert len(ticks) == 1
+            assert ticks[0]["iteration"] == 0
+            assert "scheduled_time" in ticks[0]
+            assert "actual_time" in ticks[0]
+            assert "drift_seconds" in ticks[0]
+            assert "next_scheduled_time" in ticks[0]
+            mock_sleep.assert_called()
+
+    async def test_schedules_tomorrow_if_past(self):
+        """If target time already passed today, schedules for tomorrow."""
+        from lexflow.opcodes import opcodes_schedule
+
+        # Current time is 11:00, target is 10:00 -> should schedule for tomorrow
+        now = datetime(2025, 6, 15, 11, 0, 0, 0)
+        tomorrow_target = datetime(2025, 6, 16, 10, 0, 0, 0)
+        after_sleep = tomorrow_target + timedelta(milliseconds=5)
+
+        call_count = 0
+
+        def mock_now(tz):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                return now.replace(tzinfo=tz)
+            return after_sleep.replace(tzinfo=tz)
+
+        with (
+            patch.object(opcodes_schedule, "_now", side_effect=mock_now),
+            patch("asyncio.sleep"),
+        ):
+            gen = await default_registry.call("schedule_daily", [10, 0, 0, "UTC", 1])
+            ticks = []
+            async for tick in gen:
+                ticks.append(tick)
+
+            assert "2025-06-16" in ticks[0]["scheduled_time"]
+
+    async def test_invalid_hour_raises(self):
+        with pytest.raises(ValueError, match="hour must be 0-23"):
+            await default_registry.call("schedule_daily", [25])
+
+    async def test_invalid_minute_raises(self):
+        with pytest.raises(ValueError, match="minute must be 0-59"):
+            await default_registry.call("schedule_daily", [10, 60])
+
+    async def test_invalid_second_raises(self):
+        with pytest.raises(ValueError, match="second must be 0-59"):
+            await default_registry.call("schedule_daily", [10, 0, 60])
+
+    async def test_invalid_timezone_raises(self):
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            await default_registry.call("schedule_daily", [10, 0, 0, "Nope/Zone"])
 
 
-async def test_schedule_interval_tick_structure():
-    gen = await default_registry.call("schedule_interval", [0.02, 1])
-    async for tick in gen:
-        assert "iteration" in tick
-        assert "scheduled_time" in tick
-        assert "actual_time" in tick
-        assert "drift_seconds" in tick
-        assert "next_scheduled_time" in tick
-        assert tick["iteration"] == 0
+class TestScheduleCron:
+    async def test_available_when_croniter_installed(self):
+        try:
+            import croniter  # noqa: F401
 
+            assert "schedule_cron" in default_registry.list_opcodes()
+        except ImportError:
+            assert "schedule_cron" not in default_registry.list_opcodes()
 
-async def test_schedule_interval_iterations_increment():
-    gen = await default_registry.call("schedule_interval", [0.02, 3])
-    iterations = []
-    async for tick in gen:
-        iterations.append(tick["iteration"])
-    assert iterations == [0, 1, 2]
+    async def test_tick_structure(self):
+        pytest.importorskip("croniter")
+        gen = await default_registry.call("schedule_cron", ["* * * * * *", 1])
+        ticks = []
+        async for tick in gen:
+            ticks.append(tick)
+        assert len(ticks) == 1
+        assert "iteration" in ticks[0]
+        assert "scheduled_time" in ticks[0]
+        assert "actual_time" in ticks[0]
+        assert "drift_seconds" in ticks[0]
+        assert "next_scheduled_time" in ticks[0]
 
+    async def test_invalid_expression_raises(self):
+        pytest.importorskip("croniter")
+        with pytest.raises(ValueError, match="Invalid cron expression"):
+            await default_registry.call("schedule_cron", ["not a cron"])
 
-async def test_schedule_daily_tick_structure():
-    """Test daily generator yields correct structure (with max_iterations=1 and immediate fire)."""
-    # We can't easily test daily in a unit test (would wait until target time).
-    # Instead, test that the generator is created and is an async generator.
-    gen = await default_registry.call("schedule_daily", [0, 0, 0, "UTC", 1])
-    assert hasattr(gen, "__aiter__")
-    assert hasattr(gen, "__anext__")
-
-
-async def test_schedule_cron_available():
-    """Test schedule_cron is registered when croniter is available."""
-    try:
-        import croniter  # noqa: F401
-
-        opcodes = default_registry.list_opcodes()
-        assert "schedule_cron" in opcodes
-    except ImportError:
-        opcodes = default_registry.list_opcodes()
-        assert "schedule_cron" not in opcodes
-
-
-async def test_schedule_cron_tick_structure():
-    """Test cron generator yields correct structure."""
-    pytest.importorskip("croniter")
-    # Every second — should fire very quickly
-    gen = await default_registry.call("schedule_cron", ["* * * * * *", 1])
-    ticks = []
-    async for tick in gen:
-        ticks.append(tick)
-    assert len(ticks) == 1
-    assert "iteration" in ticks[0]
-    assert "scheduled_time" in ticks[0]
-    assert "actual_time" in ticks[0]
-    assert "drift_seconds" in ticks[0]
-    assert "next_scheduled_time" in ticks[0]
-
-
-async def test_schedule_interval_with_timezone():
-    gen = await default_registry.call(
-        "schedule_interval", [0.02, 1, "America/Sao_Paulo"]
-    )
-    async for tick in gen:
-        assert "-03:00" in tick["scheduled_time"] or "-02:00" in tick["scheduled_time"]
+    async def test_invalid_timezone_raises(self):
+        pytest.importorskip("croniter")
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            await default_registry.call(
+                "schedule_cron", ["* * * * *", None, "Bad/Zone"]
+            )

--- a/tests/unit/test_schedule_opcodes.py
+++ b/tests/unit/test_schedule_opcodes.py
@@ -1,0 +1,92 @@
+"""Tests for schedule opcodes."""
+
+import pytest
+from lexflow import default_registry
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_schedule_after_returns_timing_info():
+    result = await default_registry.call("schedule_after", [0.05])
+    assert "started_at" in result
+    assert "completed_at" in result
+    assert "elapsed_seconds" in result
+    assert result["elapsed_seconds"] >= 0.05
+
+
+async def test_schedule_after_with_timezone():
+    result = await default_registry.call("schedule_after", [0.05, "America/Sao_Paulo"])
+    assert "started_at" in result
+    assert "-03:00" in result["started_at"] or "-02:00" in result["started_at"]
+
+
+async def test_schedule_interval_yields_correct_count():
+    gen = await default_registry.call("schedule_interval", [0.02, 3])
+    ticks = []
+    async for tick in gen:
+        ticks.append(tick)
+    assert len(ticks) == 3
+
+
+async def test_schedule_interval_tick_structure():
+    gen = await default_registry.call("schedule_interval", [0.02, 1])
+    async for tick in gen:
+        assert "iteration" in tick
+        assert "scheduled_time" in tick
+        assert "actual_time" in tick
+        assert "drift_seconds" in tick
+        assert "next_scheduled_time" in tick
+        assert tick["iteration"] == 0
+
+
+async def test_schedule_interval_iterations_increment():
+    gen = await default_registry.call("schedule_interval", [0.02, 3])
+    iterations = []
+    async for tick in gen:
+        iterations.append(tick["iteration"])
+    assert iterations == [0, 1, 2]
+
+
+async def test_schedule_daily_tick_structure():
+    """Test daily generator yields correct structure (with max_iterations=1 and immediate fire)."""
+    # We can't easily test daily in a unit test (would wait until target time).
+    # Instead, test that the generator is created and is an async generator.
+    gen = await default_registry.call("schedule_daily", [0, 0, 0, "UTC", 1])
+    assert hasattr(gen, "__aiter__")
+    assert hasattr(gen, "__anext__")
+
+
+async def test_schedule_cron_available():
+    """Test schedule_cron is registered when croniter is available."""
+    try:
+        import croniter  # noqa: F401
+
+        opcodes = default_registry.list_opcodes()
+        assert "schedule_cron" in opcodes
+    except ImportError:
+        opcodes = default_registry.list_opcodes()
+        assert "schedule_cron" not in opcodes
+
+
+async def test_schedule_cron_tick_structure():
+    """Test cron generator yields correct structure."""
+    pytest.importorskip("croniter")
+    # Every second — should fire very quickly
+    gen = await default_registry.call("schedule_cron", ["* * * * * *", 1])
+    ticks = []
+    async for tick in gen:
+        ticks.append(tick)
+    assert len(ticks) == 1
+    assert "iteration" in ticks[0]
+    assert "scheduled_time" in ticks[0]
+    assert "actual_time" in ticks[0]
+    assert "drift_seconds" in ticks[0]
+    assert "next_scheduled_time" in ticks[0]
+
+
+async def test_schedule_interval_with_timezone():
+    gen = await default_registry.call(
+        "schedule_interval", [0.02, 1, "America/Sao_Paulo"]
+    )
+    async for tick in gen:
+        assert "-03:00" in tick["scheduled_time"] or "-02:00" in tick["scheduled_time"]

--- a/uv.lock
+++ b/uv.lock
@@ -452,6 +452,19 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2f/44d1ae153a0e27be56be43465e5cb39b9650c781e001e7864389deb25090/croniter-6.0.0.tar.gz", hash = "sha256:37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577", size = 64481, upload-time = "2024-12-17T17:17:47.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/4b/290b4c3efd6417a8b0c284896de19b1d5855e6dbdb97d2a35e68fa42de85/croniter-6.0.0-py2.py3-none-any.whl", hash = "sha256:2f878c3856f17896979b2a4379ba1f09c83e374931ea15cc835c5dd2eee9b368", size = 25468, upload-time = "2024-12-17T17:17:45.359Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1251,6 +1264,7 @@ all = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
     { name = "bm25s" },
+    { name = "croniter" },
     { name = "fastapi" },
     { name = "gcloud-aio-pubsub" },
     { name = "gcloud-aio-storage" },
@@ -1288,6 +1302,9 @@ rag = [
     { name = "pypdf" },
     { name = "qdrant-client" },
 ]
+schedule = [
+    { name = "croniter" },
+]
 web = [
     { name = "fastapi" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1305,11 +1322,12 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'http'" },
     { name = "beautifulsoup4", marker = "extra == 'http'" },
     { name = "bm25s", marker = "extra == 'rag'" },
+    { name = "croniter", marker = "extra == 'schedule'" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.100.0" },
     { name = "gcloud-aio-pubsub", marker = "extra == 'pubsub'" },
     { name = "gcloud-aio-storage", marker = "extra == 'gcs'" },
     { name = "google-cloud-aiplatform", marker = "extra == 'rag'" },
-    { name = "lexflow", extras = ["ai", "pygame", "file", "http", "web", "rag", "gcs", "pubsub"], marker = "extra == 'all'" },
+    { name = "lexflow", extras = ["ai", "pygame", "file", "http", "web", "rag", "gcs", "pubsub", "schedule"], marker = "extra == 'all'" },
     { name = "pydantic" },
     { name = "pydantic-ai-slim", extras = ["google"], marker = "extra == 'ai'" },
     { name = "pygame", marker = "extra == 'pygame'", specifier = ">=2.6.1" },
@@ -1322,7 +1340,7 @@ requires-dist = [
     { name = "rich" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.23.0" },
 ]
-provides-extras = ["ai", "pygame", "file", "http", "gcs", "pubsub", "rag", "web", "dev", "all"]
+provides-extras = ["ai", "pygame", "file", "http", "gcs", "pubsub", "rag", "schedule", "web", "dev", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2177,6 +2195,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Adiciona opcodes de agendamento (scheduling) ao LexFlow, permitindo executar ações após um tempo determinado, em intervalos recorrentes, diariamente em horário específico, ou via expressões cron.

## Changelog

[Added]
  - Módulo `opcodes_schedule.py` com 4 novos opcodes:
    - `schedule_after(seconds, timezone?)` - Delay one-shot, retorna timing info
    - `schedule_interval(seconds, max_iterations?, timezone?)` - Timer recorrente com fixed-rate scheduling
    - `schedule_daily(hour, minute?, second?, timezone?, max_iterations?)` - Timer diário em horário específico
    - `schedule_cron(expression, max_iterations?, timezone?)` - Agendamento via expressão cron (requer `croniter`)
  - Categoria "Schedule Operations" registrada no opcode registry
  - Dependência opcional `schedule = ["croniter"]` no `pyproject.toml`
  - 3 exemplos de workflows em `examples/scheduling/`:
    - `delayed_action.yaml` - Espera N segundos e executa
    - `interval_timer.yaml` - Timer a cada 2s com 5 iterações
    - `daily_schedule.yaml` - Agendamento diário às 09:00
  - 9 testes unitários em `tests/unit/test_schedule_opcodes.py`