### PR TITLE
feat(opcodes): add description field to CategoryInfo and register decorator

### DIFF
--- a/lexflow-core/src/lexflow/opcodes/opcodes.py
+++ b/lexflow-core/src/lexflow/opcodes/opcodes.py
@@ -123,7 +123,16 @@ class OpcodeRegistry:
         Returns:
             The registered CategoryInfo
         """
-        cat = CategoryInfo(id, label, prefix, color, icon, requires, order, description)
+        cat = CategoryInfo(
+            id=id,
+            label=label,
+            prefix=prefix,
+            color=color,
+            icon=icon,
+            requires=requires,
+            order=order,
+            description=description,
+        )
         self.categories[id] = cat
         return cat
 
@@ -1049,7 +1058,7 @@ class OpcodeRegistry:
 default_registry = OpcodeRegistry()
 
 
-def opcode(name: str = None, *, category: str = None):
+def opcode(name: str = None, *, category: str = None, description: str = ""):
     """Convenience decorator for registering opcodes to the default global registry.
 
     Usage:
@@ -1061,7 +1070,7 @@ def opcode(name: str = None, *, category: str = None):
         async def my_category_op(x: int) -> int:
             return x * 2
     """
-    return default_registry.register(name, category=category)
+    return default_registry.register(name, category=category, description=description)
 
 
 def register_category(
@@ -1072,6 +1081,7 @@ def register_category(
     icon: str = "⚡",
     requires: Optional[str] = None,
     order: int = 200,
+    description: str = "",
 ) -> CategoryInfo:
     """Register a category to the default global registry.
 
@@ -1092,5 +1102,5 @@ def register_category(
             return x * 2
     """
     return default_registry.register_category(
-        id, label, prefix, color, icon, requires, order
+        id, label, prefix, color, icon, requires, order, description
     )

--- a/lexflow-core/src/lexflow/opcodes/opcodes.py
+++ b/lexflow-core/src/lexflow/opcodes/opcodes.py
@@ -18,6 +18,7 @@ class CategoryInfo:
     icon: str = "⚡"
     requires: Optional[str] = None  # pip extra required (e.g., "ai", "http")
     order: int = field(default=100)  # display order in docs
+    description: str = ""  # user-facing description (e.g., PT-BR for frontend)
 
     def to_dict(self) -> dict:
         """Convert to dict for grammar.json export."""
@@ -27,6 +28,7 @@ class CategoryInfo:
             "prefix": self.prefix,
             "color": self.color,
             "icon": self.icon,
+            "description": self.description,
         }
         if self.requires:
             d["requires"] = self.requires
@@ -43,6 +45,7 @@ class OpcodeRegistry:
         self.opcode_categories: dict[str, str] = {}  # opcode_name -> category_id
         self._privileged: set[str] = set()
         self._injected: dict[str, Callable] = {}
+        self.descriptions: dict[str, str] = {}  # opcode_name -> user-facing description
         self._register_builtin_categories()
         self._register_builtins()
 
@@ -103,6 +106,7 @@ class OpcodeRegistry:
         icon: str = "⚡",
         requires: Optional[str] = None,
         order: int = 200,
+        description: str = "",
     ) -> CategoryInfo:
         """Register a category for opcodes.
 
@@ -114,11 +118,12 @@ class OpcodeRegistry:
             icon: Emoji icon for UI display
             requires: pip extra required (e.g., "ai" for lexflow[ai])
             order: Display order in docs (lower = earlier)
+            description: User-facing description (e.g., PT-BR for frontend)
 
         Returns:
             The registered CategoryInfo
         """
-        cat = CategoryInfo(id, label, prefix, color, icon, requires, order)
+        cat = CategoryInfo(id, label, prefix, color, icon, requires, order, description)
         self.categories[id] = cat
         return cat
 
@@ -151,7 +156,7 @@ class OpcodeRegistry:
         return sorted(self.categories.values(), key=lambda c: (c.order, c.id))
 
     def register(
-        self, name: str = None, *, category: str = None, privileged: bool = False
+        self, name: str = None, *, category: str = None, privileged: bool = False, description: str = ""
     ):
         """
         Decorator to register an opcode with automatic argument unpacking.
@@ -190,6 +195,10 @@ class OpcodeRegistry:
             # Store original signature for introspection
             sig = inspect.signature(func)
             self.signatures[opcode_name] = sig
+
+            # Store user-facing description if provided
+            if description:
+                self.descriptions[opcode_name] = description
 
             if privileged:
                 # Mark as privileged - requires injection before use
@@ -339,7 +348,7 @@ class OpcodeRegistry:
         return_type = hints.get("return", Any)
         return_type_name = self._format_type_hint(return_type)
 
-        return {
+        result = {
             "name": name,
             "parameters": params,
             "return_type": return_type_name,
@@ -347,6 +356,9 @@ class OpcodeRegistry:
             if original_func.__doc__
             else None,
         }
+        if name in self.descriptions:
+            result["description"] = self.descriptions[name]
+        return result
 
     def list_opcodes(self, include_private: bool = False) -> list[str]:
         """List all registered opcodes.

--- a/tests/unit/test_opcode_descriptions.py
+++ b/tests/unit/test_opcode_descriptions.py
@@ -1,0 +1,91 @@
+"""Tests for the description field on CategoryInfo and OpcodeRegistry."""
+
+import pytest
+from lexflow.opcodes.opcodes import CategoryInfo, OpcodeRegistry
+
+
+class TestCategoryInfoDescription:
+    def test_default_description_is_empty(self):
+        cat = CategoryInfo(id="test", label="Test", prefix="test_")
+        assert cat.description == ""
+
+    def test_description_is_stored(self):
+        cat = CategoryInfo(id="test", label="Test", prefix="test_", description="Uma descricao")
+        assert cat.description == "Uma descricao"
+
+    def test_to_dict_includes_description(self):
+        cat = CategoryInfo(id="test", label="Test", prefix="test_", description="Descricao")
+        d = cat.to_dict()
+        assert "description" in d
+        assert d["description"] == "Descricao"
+
+    def test_to_dict_includes_empty_description(self):
+        cat = CategoryInfo(id="test", label="Test", prefix="test_")
+        d = cat.to_dict()
+        assert "description" in d
+        assert d["description"] == ""
+
+
+class TestRegisterCategoryDescription:
+    def test_register_category_with_description(self):
+        reg = OpcodeRegistry()
+        reg.register_category(id="test", label="Test", prefix="test_", description="Descricao teste")
+        cat = reg.categories["test"]
+        assert cat.description == "Descricao teste"
+
+    def test_register_category_without_description(self):
+        reg = OpcodeRegistry()
+        reg.register_category(id="test", label="Test", prefix="test_")
+        cat = reg.categories["test"]
+        assert cat.description == ""
+
+
+class TestOpcodeDescription:
+    def test_register_opcode_with_description(self):
+        reg = OpcodeRegistry()
+        reg.register_category(id="test", label="Test", prefix="test_")
+
+        @reg.register(category="test", description="Faz algo util")
+        async def test_do_something(x: int) -> int:
+            """Do something useful."""
+            return x
+
+        assert "test_do_something" in reg.descriptions
+        assert reg.descriptions["test_do_something"] == "Faz algo util"
+
+    def test_register_opcode_without_description(self):
+        reg = OpcodeRegistry()
+        reg.register_category(id="test", label="Test", prefix="test_")
+
+        @reg.register(category="test")
+        async def test_no_desc(x: int) -> int:
+            """No description provided."""
+            return x
+
+        assert "test_no_desc" not in reg.descriptions
+
+    def test_get_interface_includes_description(self):
+        reg = OpcodeRegistry()
+        reg.register_category(id="test", label="Test", prefix="test_")
+
+        @reg.register(category="test", description="Descricao do opcode")
+        async def test_with_desc(x: int) -> int:
+            """Technical docstring."""
+            return x
+
+        interface = reg.get_interface("test_with_desc")
+        assert interface["description"] == "Descricao do opcode"
+        assert interface["doc"] == "Technical docstring."
+
+    def test_get_interface_without_description(self):
+        reg = OpcodeRegistry()
+        reg.register_category(id="test", label="Test", prefix="test_")
+
+        @reg.register(category="test")
+        async def test_no_desc2(x: int) -> int:
+            """Technical docstring only."""
+            return x
+
+        interface = reg.get_interface("test_no_desc2")
+        assert "description" not in interface
+        assert interface["doc"] == "Technical docstring only."


### PR DESCRIPTION
## Summary
- Adds `description: str = ""` field to `CategoryInfo` dataclass
- `register_category()` and `@register()` decorator now accept a `description` parameter for user-facing text (e.g., PT-BR descriptions for the frontend catalog)
- `get_interface()` includes `description` in returned metadata when available
- Fully backward compatible — all defaults are empty string

## Context
The LexFlow web frontend needs a catalog page showing available opcodes with descriptions in Portuguese. This change allows opcode modules to provide user-facing descriptions separate from technical docstrings.

## Test plan
- [x] Existing tests pass (no breaking changes)
- [x] Verified CategoryInfo stores and exports description via `to_dict()`
- [x] Verified register() stores description and get_interface() returns it